### PR TITLE
Changed requirements version numbers to be minimum required versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-BeautifulSoup==3.2.1
-certifi==14.05.14
-chardet==2.3.0
-requesocks==0.10.8
-wsgiref==0.1.2
+BeautifulSoup>=3.2.1
+certifi>=14.05.14
+chardet>=2.3.0
+requesocks>=0.10.8
+wsgiref>=0.1.2


### PR DESCRIPTION
Changed requirements versions to be minimum required version rather than only accepted version.

Specifying requirements version numbers with == results in downgrading
systems which have a version of the required software greater (more
recent) than that listed.  By changing this to >= the requirements
should still be met without adversely affecting other software on the
system.  Explicitly setting one particular version number should only
be done when run within a virtualenv (which is probably a good idea
anyway, but not everyone will do it).
